### PR TITLE
Alert when sequencer is stuck

### DIFF
--- a/monitoring/prometheus/rules.yml
+++ b/monitoring/prometheus/rules.yml
@@ -20,18 +20,16 @@ groups:
       severity: critical
     annotations:
       summary: "Block number not incrementing"
-      description: |-
-        Block number has been stuck for over 5 minutes.
-  - alert: SequencerNonceNotIncrementing
+      description: "Block number has been stuck for over 5 minutes."
+  - alert: SequencerIsStuck
     expr: |
-      changes(sequencer_nonce[5m]) == 0
+      nonce_gap > 0 and changes(nonce_gap[5m]) == 0 and changes(sequencer_nonce[5m]) == 0
     for: 5m
     labels:
       severity: critical
     annotations:
       summary: "Sequencer nonce not incrementing"
-      description: |-
-        Sequencer nonce with value {{ $value }} has been stuck for over 5 minutes.
+      description: "Sequencer nonce hasn't increased while there is a nonce gap of {{ $value }}"
   - alert: HealthCheckFailing
     expr: |
       up{job="health_monitor"} == 0

--- a/monitoring/prometheus/rules.yml
+++ b/monitoring/prometheus/rules.yml
@@ -40,6 +40,17 @@ groups:
       summary: "Health check endpoint is down"
       description: "Health check endpoint at {{ $labels.instance }} is not responding with HTTP 200"
 # Uncomment the negating test alerts below if you want to verify slack hook works well when testing
+  - alert: TEST ALERT SequencerNonceChanging
+    expr: |
+      changes(sequencer_nonce[5m]) > 0
+    for: 5m
+    labels:
+      severity: high
+    annotations:
+      summary: '{{ $labels.label }} test alert for local testing sequencer nonce is changing'
+      description: |-
+        THIS IS JUST A TEST ALERT FOR LOCAL TESTING
+# Uncomment the negating test alerts below if you want to verify slack hook works well when testing
   # - alert: NEGATING TEST ALERT AccountBalanceLow
   #   expr: |
   #     balance_account > 0.5

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,8 @@ lazy_static! {
             .expect("Cannot create block metric");
     pub static ref SEQUENCER_NONCE: IntGauge =
         register_int_gauge!("sequencer_nonce", "Current sequencer nonce")
-            .expect("Cannot create none metric");
+            .expect("Cannot create nonce metric");
+    pub static ref SEQUENCER_NONCE_GAP: IntGauge =
+        register_int_gauge!("nonce_gap", "Sequencer nonce gap")
+            .expect("Cannot create nonce gap metric");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ async fn main() -> std::io::Result<()> {
             address: address!("aa52Be611a9b620aFF67FbC79326e267cc3F2c69"),
             label: "sponsor".to_string(),
         },
+        Account {
+            address: address!("238c8CD93ee9F8c7Edf395548eF60c0d2e46665E"),
+            label: "exp002_sponsor".to_string(),
+        },
     ];
 
     let config = MonitorConfig::new(accounts);

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,5 +1,5 @@
 use crate::{app::AppSettings, BALANCE_ACCOUNT};
-use crate::{CURRENT_BLOCK, SEQUENCER_NONCE};
+use crate::{CURRENT_BLOCK, SEQUENCER_NONCE, SEQUENCER_NONCE_GAP};
 use alloy::primitives::utils::format_units;
 use alloy::primitives::Address;
 use alloy::providers::Provider;
@@ -63,6 +63,11 @@ pub async fn run_monitoring(
             .block_id(block.header.number.into())
             .into_future();
 
+        let pending_nonce_fut = provider
+            .get_transaction_count(sequencer)
+            .pending()
+            .into_future();
+
         let balances_fut = config
             .accounts
             .iter()
@@ -74,11 +79,19 @@ pub async fn run_monitoring(
             })
             .collect::<Vec<_>>();
 
-        let (sequencer_nonce, balances) = join!(nonce_fut, join_all(balances_fut));
+        let (sequencer_nonce, sequencer_nonce_pending, balances) =
+            join!(nonce_fut, pending_nonce_fut, join_all(balances_fut));
 
-        if let Ok(sequencer_nonce) = sequencer_nonce {
+        if let (Ok(sequencer_nonce), Ok(pending_nonce)) = (sequencer_nonce, sequencer_nonce_pending) {
             tracing::info!("#️⃣  Sequencer Nonce : {:?}", sequencer_nonce);
             SEQUENCER_NONCE.set(sequencer_nonce as i64);
+
+            let nonce_gap = pending_nonce.saturating_sub(sequencer_nonce);
+            SEQUENCER_NONCE_GAP.set(nonce_gap as i64);
+            tracing::info!(
+                "📨 Sequencer nonce gap: {:?}",
+                nonce_gap,
+            );
         }
 
         for (account, balance) in config.accounts.iter().zip(balances) {


### PR DESCRIPTION
**Description:** Need to alert if sequencer is stuck due to nonce gap

**Algorithm:**
- If no transactions are going through: nonce gap=0 and sequencer_nonce doesn't change
- If transactions are going through: nonce_gap > 0 and changing and sequencer nonce is also changing 
- If sequencer is stuck then nonce_gap > 0 AND it's not changing and sequencer nonce isn't changing, we're stuck --> ALERT will be sent to slack if we're stuck for over 5mins.