### PR TITLE
Remove erc20_sponsor from alerts

### DIFF
--- a/monitoring/prometheus/rules.yml
+++ b/monitoring/prometheus/rules.yml
@@ -3,14 +3,14 @@ groups:
   rules:
   - alert: AccountBalanceLow
     expr: |
-      balance_account < 0.5
+      balance_account < 0.1
     for: 5m
     labels:
       severity: high
     annotations:
       summary: '{{ $labels.label }} account balance is too low ({{ $value }} ETH)'
       description: |-
-        Account {{ $labels.label }} ({{ $labels.address }}) has a balance of {{ $value }} ETH, which is below 1 ETH threshold.
+        Account {{ $labels.label }} ({{ $labels.address }}) has a balance of {{ $value }} ETH, which is below 0.1 ETH threshold.
         Please top up this account.
   - alert: BlockNotIncrementing
     expr: |
@@ -39,17 +39,6 @@ groups:
     annotations:
       summary: "Health check endpoint is down"
       description: "Health check endpoint at {{ $labels.instance }} is not responding with HTTP 200"
-# Uncomment the negating test alerts below if you want to verify slack hook works well when testing
-  # - alert: TEST ALERT SequencerNonceChanging
-  #   expr: |
-  #     changes(sequencer_nonce[5m]) > 0
-  #   for: 5m
-  #   labels:
-  #     severity: high
-  #   annotations:
-  #     summary: '{{ $labels.label }} test alert for local testing sequencer nonce is changing'
-  #     description: |-
-  #       THIS IS JUST A TEST ALERT FOR LOCAL TESTING
 # Uncomment the negating test alerts below if you want to verify slack hook works well when testing
   # - alert: NEGATING TEST ALERT AccountBalanceLow
   #   expr: |

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,17 +12,10 @@ async fn main() -> std::io::Result<()> {
 
     tracing_subscriber::fmt::init();
 
-    // TODO: should make this configurable
-    let accounts = vec![
-        Account {
-            address: address!("1234562C27E07675Fe8ed90BbFB9a62853edCBb2"),
-            label: "sequencer".to_string(),
-        },
-        Account {
-            address: address!("238c8CD93ee9F8c7Edf395548eF60c0d2e46665E"),
-            label: "exp_erc20_contract".to_string(),
-        },
-    ];
+    let accounts = vec![Account {
+        address: address!("1234562C27E07675Fe8ed90BbFB9a62853edCBb2"),
+        label: "sequencer".to_string(),
+    }];
 
     let config = MonitorConfig::new(accounts);
 

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -16,16 +16,10 @@ struct TestApp {
 
 impl TestApp {
     async fn new() -> Self {
-        let acc_to_monitor = vec![
-            Account {
-                address: address!("1234562C27E07675Fe8ed90BbFB9a62853edCBb2"),
-                label: "sequencer".to_string(),
-            },
-            Account {
-                address: address!("aa52Be611a9b620aFF67FbC79326e267cc3F2c69"),
-                label: "exp_er20_contract".to_string(),
-            },
-        ];
+        let acc_to_monitor = vec![Account {
+            address: address!("1234562C27E07675Fe8ed90BbFB9a62853edCBb2"),
+            label: "sequencer".to_string(),
+        }];
 
         let mut config = MonitorConfig::new(acc_to_monitor);
         config.app_settings.port = 0;


### PR DESCRIPTION
We replaced the sepolia ETH swap with swapping between EXP1<>EXP2 tokens which should prevent us from having to top up the erc20_sponsor constantly